### PR TITLE
Call as_bytes instead of to_string() to skip unnecessary utf8 parsing.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,7 +237,7 @@ impl<'a, 's, 't> Context<'a, 's, 't> {
                     Some(rva) => rva.0,
                     None => continue,
                 };
-                if name.to_string().starts_with('?') {
+                if name.as_bytes().starts_with(&[b'?']) {
                     decorated_symbol_names.insert(start_rva, name);
                 }
                 functions.push(BasicFunctionInfo {


### PR DESCRIPTION
In one testcase, make_context spent 6.6% of its time doing utf-8 parsing.
Before: https://share.firefox.dev/3mmKcJm
After: https://share.firefox.dev/3kbTHZd