### PR TITLE
Parse modules on demand, and find the right module using section contributions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,11 @@ version = "0.4.2"
 [dependencies]
 bitflags = "1.0"
 maybe-owned = "0.3.4"
-pdb = "0.7.0"
+# pdb = "0.7.0"
+pdb = { path = "../pdb" }
 range-collections = "0.1.1"
 thiserror = "1.0"
+elsa = "1.4.0"
 
 [dev-dependencies]
 clap = "2"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,35 @@
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("Formatting error: {0}")]
+    FormatError(#[source] std::fmt::Error),
+
+    #[error("PDB error: {0}")]
+    PdbError(#[source] pdb::Error),
+
+    #[error("Unexpected type for argument list")]
+    ArgumentTypeNotArgumentList,
+
+    #[error("Id of type Function doesn't have type of Procedure")]
+    FunctionIdIsNotProcedureType,
+
+    #[error("Id of type MemberFunction doesn't have type of MemberFunction")]
+    MemberFunctionIdIsNotMemberFunctionType,
+
+    #[error("There are consecutive section contributions for module {0} and section {1} which are not ordered by offset")]
+    UnorderedSectionContributions(u16, u16),
+
+    #[error("Overlapping section contributions in section {0} from modules {1} and {2}")]
+    OverlappingSectionContributions(u16, u16, u16),
+}
+
+impl From<pdb::Error> for Error {
+    fn from(err: pdb::Error) -> Self {
+        Self::PdbError(err)
+    }
+}
+
+impl From<std::fmt::Error> for Error {
+    fn from(err: std::fmt::Error) -> Self {
+        Self::FormatError(err)
+    }
+}

--- a/src/type_formatter.rs
+++ b/src/type_formatter.rs
@@ -1,3 +1,4 @@
+use crate::error::Error;
 use bitflags::bitflags;
 use pdb::{
     ArgumentList, ArrayType, ClassKind, ClassType, DebugInformation, FallibleIterator,
@@ -12,36 +13,6 @@ use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fmt::Write;
 use std::ops::Bound;
-
-#[derive(thiserror::Error, Debug)]
-pub enum Error {
-    #[error("Formatting error: {0}")]
-    FormatError(#[source] std::fmt::Error),
-
-    #[error("PDB error: {0}")]
-    PdbError(#[source] pdb::Error),
-
-    #[error("Unexpected type for argument list")]
-    ArgumentTypeNotArgumentList,
-
-    #[error("Id of type Function doesn't have type of Procedure")]
-    FunctionIdIsNotProcedureType,
-
-    #[error("Id of type MemberFunction doesn't have type of MemberFunction")]
-    MemberFunctionIdIsNotMemberFunctionType,
-}
-
-impl From<pdb::Error> for Error {
-    fn from(err: pdb::Error) -> Self {
-        Self::PdbError(err)
-    }
-}
-
-impl From<std::fmt::Error> for Error {
-    fn from(err: std::fmt::Error) -> Self {
-        Self::FormatError(err)
-    }
-}
 
 type Result<V> = std::result::Result<V, Error>;
 


### PR DESCRIPTION
Fixes #29.

This is a huge speedup if only a small number of modules are needed for the addresses that are looked up.