### PR TITLE
Make sure test fixtures aren't included in the package.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ name = "pdb-addr2line"
 readme = "Readme.md"
 repository = "https://github.com/mstange/pdb-addr2line"
 version = "0.6.0"
+exclude = ["/.github", "/tests"]
 
 [dependencies]
 bitflags = "1.0"


### PR DESCRIPTION
https://crates.io/crates/pdb-addr2line currently displays  2.02 MB as the size.
I think that's because the pdb fixture files are included in the package... this change removes them again.