### PR TITLE
Ignore global public symbols outside the section contribution.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -611,8 +611,8 @@ impl<'a, 's> Context<'a, 's> {
             }
         };
 
-        let module_index = self.section_contributions[sc_index].module_index;
-        let basic_module_info = module_cache.get_basic_module_info(module_index);
+        let sc = &self.section_contributions[sc_index];
+        let basic_module_info = module_cache.get_basic_module_info(sc.module_index);
 
         if let Some(BasicModuleInfo {
             procedures,
@@ -634,7 +634,7 @@ impl<'a, 's> Context<'a, 's> {
             }) {
                 // Found a procedure at the requested offset.
                 return Some(PublicOrProcedureSymbol::Procedure(
-                    module_index,
+                    sc.module_index,
                     module_info,
                     &procedures[procedure_index],
                 ));
@@ -662,6 +662,10 @@ impl<'a, 's> Context<'a, 's> {
                     && fun.start_offset.offset <= offset.offset)
         );
         if fun.start_offset.section != offset.section {
+            return None;
+        }
+        // Ignore symbols outside the section contribution.
+        if fun.start_offset.offset < sc.start_offset {
             return None;
         }
 


### PR DESCRIPTION
Let's say you have the following section contributions:

Contribution which starts at 0x10 and contains global public symbol A
Contribution which starts at 0x20 and contains no symbols.
Contribution which starts at 0x30.

If you look up 0x25, in the past we'd fall back to symbol A. However, usually symbol A doesn't describe the code at 0x25, otherwise the section contribution that starts at 0x10 would be larger and encompass 0x25.
To avoid misleading function names, this PR makes us ignore global symbols outside the section contribution that contains the looked-up address. So in the example above, we will now return None (no function found).