### PR TITLE
add another check for no_arguments flag

### DIFF
--- a/src/type_formatter.rs
+++ b/src/type_formatter.rs
@@ -292,9 +292,12 @@ impl<'cache, 'a, 's> TypeFormatterForModule<'cache, 'a, 's> {
             TypeData::Procedure(t) => {
                 self.maybe_emit_return_type(w, t.return_type, t.attributes)?;
                 self.emit_name_str(w, name)?;
-                write!(w, "(")?;
-                self.emit_type_index(w, t.argument_list)?;
-                write!(w, ")")?;
+
+                if !self.has_flags(TypeFormatterFlags::NO_ARGUMENTS) {
+                    write!(w, "(")?;
+                    self.emit_type_index(w, t.argument_list)?;
+                    write!(w, ")")?;
+                }
             }
             _ => {
                 write!(w, "{}", name)?;

--- a/tests/type_formatter.rs
+++ b/tests/type_formatter.rs
@@ -3,7 +3,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use pdb::IdIndex;
+use pdb::{IdIndex, TypeIndex};
 use pdb_addr2line::{pdb, ContextPdbData, TypeFormatterFlags};
 
 /// Returns the full path to the specified fixture.
@@ -49,6 +49,22 @@ fn test() -> Result<(), Box<dyn Error>> {
         formatter.format_id(4, IdIndex(0x80000007))?,
         "std::_Adjust_manually_vector_aligned(void*&, unsigned int&)"
     );
+    assert_eq!(
+        formatter.format_id(2, IdIndex(0x11c2))?,
+        "std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t> >::_Calculate_growth(const unsigned int) const"
+    );
+    assert_eq!(
+        formatter.format_id(2, IdIndex(0x1169))?,
+        "std::_Adjust_manually_vector_aligned(void*&, unsigned int&)"
+    );
+    assert_eq!(
+        formatter.format_function("name", 2, TypeIndex(0x13f4))?,
+        "name(wchar_t const* const, const unsigned int)"
+    );
+    assert_eq!(
+        formatter.format_function("name", 5, TypeIndex(0x225d))?,
+        "name()"
+    );
 
     assert_eq!(
         formatter_without_args.format_id(4, IdIndex(0x80000013))?,
@@ -57,6 +73,22 @@ fn test() -> Result<(), Box<dyn Error>> {
     assert_eq!(
         formatter_without_args.format_id(4, IdIndex(0x80000007))?,
         "std::_Adjust_manually_vector_aligned"
+    );
+    assert_eq!(
+        formatter_without_args.format_id(2, IdIndex(0x11c2))?,
+        "std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t> >::_Calculate_growth"
+    );
+    assert_eq!(
+        formatter_without_args.format_id(2, IdIndex(0x1169))?,
+        "std::_Adjust_manually_vector_aligned"
+    );
+    assert_eq!(
+        formatter_without_args.format_function("name", 2, TypeIndex(0x13f4))?,
+        "name"
+    );
+    assert_eq!(
+        formatter_without_args.format_function("name", 5, TypeIndex(0x225d))?,
+        "name"
     );
 
     Ok(())


### PR DESCRIPTION
Fixed a remaining place where it's needed to check for the flag.
There are some other places which I'm not sure about, maybe you can decide:
https://github.com/mstange/pdb-addr2line/blob/main/src/type_formatter.rs#L791-L794
https://github.com/mstange/pdb-addr2line/blob/main/src/type_formatter.rs#L810-L812
https://github.com/mstange/pdb-addr2line/blob/main/src/type_formatter.rs#L1123-L1125