### PR TITLE
Allow Context/ContextPdbData to impl Send.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["/.github", "/tests"]
 [dependencies]
 bitflags = "2.0"
 maybe-owned = "0.3.4"
-pdb = "0.8.0"
+pdb = { package = "pdb2", version = "0.9" }
 range-collections = "0.4.5"
 thiserror = "1.0"
 elsa = "1.9.0"

--- a/examples/pdb-addr2line.rs
+++ b/examples/pdb-addr2line.rs
@@ -276,7 +276,7 @@ impl<'s> pdb::Source<'s> for Source {
     fn view(
         &mut self,
         slices: &[pdb::SourceSlice],
-    ) -> Result<Box<dyn pdb::SourceView<'s>>, std::io::Error> {
+    ) -> Result<Box<dyn pdb::SourceView<'s> + Send + Sync>, std::io::Error> {
         let len = slices.iter().fold(0, |acc, s| acc + s.size);
 
         let mut bytes = Vec::with_capacity(len);


### PR DESCRIPTION
This allows `wholesym` structures to be `Send`, which is necessary to use them across await points.